### PR TITLE
Revert encoding of keys and buckets as base16

### DIFF
--- a/src/krc_pb_client.erl
+++ b/src/krc_pb_client.erl
@@ -40,11 +40,8 @@
 %%%_* Code =============================================================
 delete(Pid, Bucket, Key, Options, Timeout) ->
   case
-    riakc_pb_socket:delete(Pid,
-			   krc_obj:encode_key(Bucket),
-			   krc_obj:encode_key(Key),
-			   Options,
-			   Timeout)
+    riakc_pb_socket:delete(
+      Pid, krc_obj:encode(Bucket), krc_obj:encode(Key), Options, Timeout)
   of
     ok               -> ok;
     {error, _} = Err -> Err
@@ -52,11 +49,8 @@ delete(Pid, Bucket, Key, Options, Timeout) ->
 
 get(Pid, Bucket, Key, Options, Timeout) ->
   case
-    riakc_pb_socket:get(Pid,
-			krc_obj:encode_key(Bucket),
-			krc_obj:encode_key(Key),
-			Options,
-			Timeout)
+    riakc_pb_socket:get(
+      Pid, krc_obj:encode(Bucket), krc_obj:encode(Key), Options, Timeout)
   of
     {ok, Obj}        -> {ok, krc_obj:from_riakc_obj(Obj)};
     {error, _} = Err -> Err
@@ -65,7 +59,7 @@ get(Pid, Bucket, Key, Options, Timeout) ->
 get_bucket(Pid, Bucket, Timeout) ->
   case
     riakc_pb_socket:get_bucket(Pid,
-			       krc_obj:encode_key(Bucket),
+			       krc_obj:encode(Bucket),
 			       Timeout) of
     {ok, Props}      -> {ok, krc_bucket_properties:decode(Props)};
     {error, _} = Err -> Err
@@ -75,13 +69,13 @@ get_index(Pid, Bucket, Index, Key, Timeout) ->
   {Idx, IdxKey} = krc_obj:encode_index({Index, Key}),
   case
     riakc_pb_socket:get_index(Pid,
-                              krc_obj:encode_key(Bucket),
+                              krc_obj:encode(Bucket),
                               Idx,
                               IdxKey,
                               Timeout,
                               infinity) %gen_server call
   of
-    {ok, Keys}       -> {ok, [krc_obj:decode_key(K) || K <- Keys]};
+    {ok, Keys}       -> {ok, [krc_obj:decode(K) || K <- Keys]};
     {error, _} = Err -> Err
   end.
 
@@ -90,14 +84,14 @@ get_index(Pid, Bucket, Index, Lower, Upper, Timeout) ->
   {Idx, UpperKey} = krc_obj:encode_index({Index, Upper}),
   case
     riakc_pb_socket:get_index(Pid,
-                              krc_obj:encode_key(Bucket),
+                              krc_obj:encode(Bucket),
                               Idx,
                               LowerKey,
                               UpperKey,
                               Timeout,
                               infinity) %gen_server call
   of
-    {ok, Keys}       -> {ok, [krc_obj:decode_key(K) || K <- Keys]};
+    {ok, Keys}       -> {ok, [krc_obj:decode(K) || K <- Keys]};
     {error, _} = Err -> Err
   end.
 
@@ -112,7 +106,7 @@ put(Pid, Obj, Options, Timeout) ->
 set_bucket(Pid, Bucket, Props, Timeout) ->
   case
     riakc_pb_socket:set_bucket(Pid,
-			       krc_obj:encode_key(Bucket),
+			       krc_obj:encode(Bucket),
 			       Props,
 			       Timeout) of
     ok               -> ok;


### PR DESCRIPTION
This reverts commit 05f45409b454c4c80074cf80d74e6e4f729ca146.

Conflicts:
    src/krc_obj.erl
    src/krc_pb_client.erl
